### PR TITLE
Cambiato endpoint criteria filtraLuoghi da GetMapping a PostMapping. Inserito filter su filtraLuoghi per ottenere solo luoghi non cancellati.

### DIFF
--- a/src/main/java/it/dedagroup/venditabiglietti/controller/LuogoController.java
+++ b/src/main/java/it/dedagroup/venditabiglietti/controller/LuogoController.java
@@ -203,7 +203,7 @@ public class LuogoController {
         return ResponseEntity.ok(luogoService.findAllLuogoByNazionalitaAndComune(nazionalita, comune));
     }
 
-    @GetMapping(FILTRO_LUOGHI)
+    @PostMapping(FILTRO_LUOGHI)
     public ResponseEntity<List<Luogo>> filtraLuoghi(@RequestBody FiltroLuogoDTORequest request){
         return ResponseEntity.ok(luogoService.filtraLuoghi(request));
     }

--- a/src/main/java/it/dedagroup/venditabiglietti/service/impl/LuogoServiceImpl.java
+++ b/src/main/java/it/dedagroup/venditabiglietti/service/impl/LuogoServiceImpl.java
@@ -126,7 +126,7 @@ public class LuogoServiceImpl implements LuogoServiceDef {
 
 	@Override
 	public List<Luogo> filtraLuoghi(FiltroLuogoDTORequest request) {
-		return luogoCriteriaQuery.findFiltrati(request);
+		return luogoCriteriaQuery.findFiltrati(request).stream().filter(l-> !l.isCancellato()).toList();
 	}
 	@Override
 	public List<Luogo> filtraLuoghiMap(Map<String, String> mapLuogo) {


### PR DESCRIPTION
Cambiato endpoint criteria filtraLuoghi da GetMapping a PostMapping (altrimenti da errore sulla criteria di eventiFiltrati del principale). Inserito filter su filtraLuoghi per ottenere solo luoghi non cancellati.